### PR TITLE
Docker fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,12 @@ RUN autoreconf . -i && \
 ENV CPPUTEST_HOME=/opt/cpputest
 
 # Install leagcy-build
-WORKDIR /home/legacy-build
+WORKDIR /opt/legacy-build
 RUN git clone --depth 1 https://github.com/jwgrenning/legacy-build.git .
 RUN git submodule update --init --recursive
-ENV LEGACY_BUILD="/home/legacy-build"
+ENV LEGACY_BUILD="/opt/legacy-build"
 RUN echo '#!/bin/bash' >>/usr/bin/legacy-build && \
-    echo '/home/legacy-build/legacy-build.sh $1 $2 $3' >>/usr/bin/legacy-build && \
+    echo '/opt/legacy-build/legacy-build.sh $1 $2 $3' >>/usr/bin/legacy-build && \
         chmod +x /usr/bin/legacy-build
 RUN echo 'echo run "make -C <test-makefile-dir>/" or "legacy-build"' >> ~/.bashrc
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcc:12.2.0
 
 # Install cpputest
-WORKDIR /home/cpputest
+WORKDIR /opt/cpputest
 
 RUN git clone --depth 1 --branch v4.0 https://github.com/cpputest/cpputest.git .
 RUN autoreconf . -i && \
@@ -9,7 +9,7 @@ RUN autoreconf . -i && \
     make tdd && \
     make install 
 
-ENV CPPUTEST_HOME="/home/cpputest"
+ENV CPPUTEST_HOME=/opt/cpputest
 
 # Install leagcy-build
 WORKDIR /home/legacy-build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:11.2.0
+FROM gcc:12.2.0
 
 # Install cpputest
 WORKDIR /home/cpputest


### PR DESCRIPTION
- update GCC to 12.2.0
- install CPPUTest and legacy-build tool in /opt because /home gets obscured by the host mount with docker, making both inaccessible